### PR TITLE
Backfill missing lab metadata (5 files)

### DIFF
--- a/Instructions/Labs/M02-explore-prebuilt-microsoft-365-copilot-agents/03-exercise-analyst-agent.md
+++ b/Instructions/Labs/M02-explore-prebuilt-microsoft-365-copilot-agents/03-exercise-analyst-agent.md
@@ -1,3 +1,12 @@
+---
+lab:
+  title: Untitled exercise
+  description: In this scenario-based exercise, you learn how to use the Analyst agent to explore trends, identify anomalies, and generate visuals that enhance data storytelling. Whether you're reporting on team performance, customer feedback, or operational metrics, this lab shows you how to go from raw numbers to a clear summary or stakeholder-ready charts. It's a powerful way to save time, reduce manual effort, and build confidence in your analytical decision-making with AI-powered support.
+  duration: 32 minutes
+  level: 100
+  islab: true
+---
+
 As organizations become more data-driven, the ability to quickly interpret and communicate insights from raw information is a critical skill. Microsoft 365 Copilot's Analyst agent empowers users to do just that by analyzing and visualizing data directly within familiar tools like Excel and Forms. This lab provides a practical walkthrough of how to use the Analyst agent to make sense of existing datasets—whether from surveys, spreadsheets, or poll results—and turn them into actionable insights with minimal effort.
 
 In this scenario-based exercise, you learn how to use the Analyst agent to explore trends, identify anomalies, and generate visuals that enhance data storytelling. Whether you're reporting on team performance, customer feedback, or operational metrics, this lab shows you how to go from raw numbers to a clear summary or stakeholder-ready charts. It's a powerful way to save time, reduce manual effort, and build confidence in your analytical decision-making with AI-powered support.

--- a/Instructions/Labs/M02-explore-prebuilt-microsoft-365-copilot-agents/05-exercise-researcher-agent.md
+++ b/Instructions/Labs/M02-explore-prebuilt-microsoft-365-copilot-agents/05-exercise-researcher-agent.md
@@ -1,3 +1,14 @@
+---
+lab:
+  title: Untitled exercise
+  description: This lab offers a hands-on opportunity to explore how the Researcher agent can help you uncover insights, organize information, and generate polished outputs from your own data, all within the familiar Microsoft 365 environment. Whether you're consolidating project updates, gathering stakeholder input, or preparing for executive discussions, this lab demonstrates how Copilot can enhance your productivity and ensure you're always ready with the right information at the right time.
+  duration: 28 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Microsoft 365
+---
+
 In today's fast-paced workplace, the ability to quickly synthesize large volumes of information is essential for making informed decisions and preparing effectively for meetings and presentations. Microsoft 365 Copilot's Researcher agent is designed to support this need by intelligently pulling together relevant content from across Outlook, OneDrive, and Teams. 
 
 This lab offers a hands-on opportunity to explore how the Researcher agent can help you uncover insights, organize information, and generate polished outputs from your own data, all within the familiar Microsoft 365 environment. Whether you're consolidating project updates, gathering stakeholder input, or preparing for executive discussions, this lab demonstrates how Copilot can enhance your productivity and ensure you're always ready with the right information at the right time.

--- a/Instructions/Labs/M02-explore-prebuilt-microsoft-365-copilot-agents/10-exercise-agent-choice.md
+++ b/Instructions/Labs/M02-explore-prebuilt-microsoft-365-copilot-agents/10-exercise-agent-choice.md
@@ -1,3 +1,14 @@
+---
+lab:
+  title: Untitled exercise
+  description: Once you select an agent, you should explore its capabilities using your own Microsoft 365 data, such as emails, meetings, files, or chat threads. Your goal is to see if you can move the project forward or uncover something you missed. At the end of this exercise, you're also encouraged to try some of the other prebuilt agents to see the types of requests they can help with.
+  duration: 24 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Microsoft 365
+---
+
 With a growing ecosystem of specialized, AI-powered agents in Microsoft 365 Copilot, users now have the flexibility to choose the right tool for the task at hand. Whether you're preparing for meetings, managing projects, catching up on missed communications, or analyzing data, prebuilt agents are designed to streamline your workflow using your own Microsoft 365 data. This lab offers an open-ended, hands-on opportunity to explore one of these agents, test its capabilities, and apply it to a real productivity challenge from your day-to-day work.
 
 > [!NOTE]

--- a/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/6-exercise-create-copilot-chat-agent.md
+++ b/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/6-exercise-create-copilot-chat-agent.md
@@ -1,3 +1,12 @@
+---
+lab:
+  title: Untitled exercise
+  description: In this exercise, you're encouraged to be creative and design an agent that's of significant interest to you. For example, you might want to solve a real-world business problem, improve productivity in a specific area at your company, or address a personal topic that interests you. Because each student creates their own personal agent, the instructions in this exercise focus on the structure and order of how to configure an agent rather than specifying actual values to enter in each field. It's up to you to decide what you want to enter in each field as you create your agent.
+  duration: 54 minutes
+  level: 100
+  islab: true
+---
+
 In this exercise, you're encouraged to be creative and design an agent that's of significant interest to you. For example, you might want to solve a real-world business problem, improve productivity in a specific area at your company, or address a personal topic that interests you. Because each student creates their own personal agent, the instructions in this exercise focus on the structure and order of how to configure an agent rather than specifying actual values to enter in each field. It's up to you to decide what you want to enter in each field as you create your agent.
 
 1. In your Microsoft Edge browser, sign in to the **Microsoft 365** home page (**https://www.microsoft365.com**).

--- a/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/8-exercise-create-sharepoint-agent.md
+++ b/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/8-exercise-create-sharepoint-agent.md
@@ -1,3 +1,12 @@
+---
+lab:
+  title: Untitled exercise
+  description: 'In this exercise, you want to create a SharePoint agent to help you get quick answers or perform useful actions that are related to a specific SharePoint site you already use. You can perform this exercise using one of the following options:'
+  duration: 48 minutes
+  level: 100
+  islab: true
+---
+
 As organizations rely more heavily on SharePoint to manage knowledge, projects, and team resources, the ability to create intelligent agents that interact with this content becomes a powerful productivity booster. Microsoft 365 Copilot makes it possible to build a SharePoint-based Copilot agent that can quickly surface information, answer questions, and assist users in navigating complex site content. This lab guides you through the process of creating your own SharePoint-connected Copilot agent, one that understands the structure and data of a real site you use every day.
 
 Through this hands-on exercise, you learn how to create a SharePoint site, configure it as a data source, and customize your agent's behavior and responses. From onboarding support to project tracking or team resource assistance, you design and test an agent tailored to your needs. After you complete this lab, you should have a functioning SharePoint agent and a deeper understanding of how AI can make site content more accessible and actionable for users across your team or organization.


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 5

- `Instructions/Labs/M02-explore-prebuilt-microsoft-365-copilot-agents/03-exercise-analyst-agent.md` (front_matter_created,lab_mapping_created,title,description,duration,level,islab)
- `Instructions/Labs/M02-explore-prebuilt-microsoft-365-copilot-agents/05-exercise-researcher-agent.md` (front_matter_created,lab_mapping_created,title,description,duration,level,islab,primarytopics)
- `Instructions/Labs/M02-explore-prebuilt-microsoft-365-copilot-agents/10-exercise-agent-choice.md` (front_matter_created,lab_mapping_created,title,description,duration,level,islab,primarytopics)
- `Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/6-exercise-create-copilot-chat-agent.md` (front_matter_created,lab_mapping_created,title,description,duration,level,islab)
- `Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/8-exercise-create-sharepoint-agent.md` (front_matter_created,lab_mapping_created,title,description,duration,level,islab)
