### PR TITLE
fix(m03/ex06): update Agent Builder exercise for current UI

### DIFF
--- a/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/6-exercise-create-copilot-chat-agent.md
+++ b/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/6-exercise-create-copilot-chat-agent.md
@@ -21,7 +21,7 @@ In this exercise, you're encouraged to be creative and design an agent that's of
 
     - The Agent Builder chat pane on the left enables you to carry on a conversation with Agent Builder to refine your agent.
 
-    - The **Try It** tab enables you to test the agent by entering starter prompts or custom messages. This tab is displayed by default.
+    - The **Try It** tab enables you to test the agent by entering starter prompts or custom messages.
 
     - The **Configure** tab enables you to define the detailed settings that drive the agent.
 

--- a/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/6-exercise-create-copilot-chat-agent.md
+++ b/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/6-exercise-create-copilot-chat-agent.md
@@ -1,6 +1,6 @@
 ---
 lab:
-  title: Untitled exercise
+  title: Exercise - Create a Copilot chat agent
   description: In this exercise, you're encouraged to be creative and design an agent that's of significant interest to you. For example, you might want to solve a real-world business problem, improve productivity in a specific area at your company, or address a personal topic that interests you. Because each student creates their own personal agent, the instructions in this exercise focus on the structure and order of how to configure an agent rather than specifying actual values to enter in each field. It's up to you to decide what you want to enter in each field as you create your agent.
   duration: 54 minutes
   level: 100

--- a/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/6-exercise-create-copilot-chat-agent.md
+++ b/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/6-exercise-create-copilot-chat-agent.md
@@ -17,7 +17,7 @@ In this exercise, you're encouraged to be creative and design an agent that's of
 
 1. On the **New Agent** page, enter a prompt that asks Agent Builder to create your new agent. In the prompt, enter the agent’s name along with a brief description that explains what the agent is for, who its target audience is, and what you want it to do. Although you can choose a template at the bottom of the page to base your agent on, don't select a template for this exercise. The purpose of this exercise is to create a fully custom agent from scratch.
 
-1. After you enter a description and select the **Send** button, the **Agent Builder** form should appear for your new agent. The Agent Builder chat pane appears on the left, and the agent details appear on the right. At the top of the form are a **Configure** tab and a **Try It** tab.
+1. After you enter a description and select the **Send** button, the **Agent Builder** form should appear for your new agent. The **Agent Builder** chat pane appears on the left, and the agent details appear on the right. At the top of the form are a **Configure** tab and a **Try It** tab.
 
     - The Agent Builder chat pane on the left enables you to carry on a conversation with Agent Builder to refine your agent.
 

--- a/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/6-exercise-create-copilot-chat-agent.md
+++ b/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/6-exercise-create-copilot-chat-agent.md
@@ -9,6 +9,8 @@ lab:
 
 In this exercise, you're encouraged to be creative and design an agent that's of significant interest to you. For example, you might want to solve a real-world business problem, improve productivity in a specific area at your company, or address a personal topic that interests you. Because each student creates their own personal agent, the instructions in this exercise focus on the structure and order of how to configure an agent rather than specifying actual values to enter in each field. It's up to you to decide what you want to enter in each field as you create your agent.
 
+### Exercise - Build a custom agent with Agent Builder
+
 1. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page [**https://m365.cloud.microsoft.com**](https://m365.cloud.microsoft.com).
 
 1. In **Microsoft 365 Copilot**, select **New agent** in the navigation pane. Doing so opens Agent Builder and displays the **New Agent** page.

--- a/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/6-exercise-create-copilot-chat-agent.md
+++ b/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/6-exercise-create-copilot-chat-agent.md
@@ -9,15 +9,17 @@ lab:
 
 In this exercise, you're encouraged to be creative and design an agent that's of significant interest to you. For example, you might want to solve a real-world business problem, improve productivity in a specific area at your company, or address a personal topic that interests you. Because each student creates their own personal agent, the instructions in this exercise focus on the structure and order of how to configure an agent rather than specifying actual values to enter in each field. It's up to you to decide what you want to enter in each field as you create your agent.
 
-1. In your Microsoft Edge browser, sign in to the **Microsoft 365** home page (**https://www.microsoft365.com**).
+1. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page [**https://m365.cloud.microsoft.com**](https://m365.cloud.microsoft.com).
 
-1. In Microsoft 365, select **New agent** in the navigation pane. Doing so opens Agent Builder and displays the **New Agent** page. 
+1. In **Microsoft 365 Copilot**, select **New agent** in the navigation pane. Doing so opens Agent Builder and displays the **New Agent** page.
 
-1. On the **New Agent** page, enter a prompt that asks Agent Builder to create your new agent. In the prompt, enter the agent’s name along with a brief description that explains what the agent is for, who its target audience is, and what you want it to do. Although you can choose a template at the bottom of the page to base your agent on, don't select a template for this exercise. The purpose of this exercise is to create a fully custom agent from scratch. 
+1. On the **New Agent** page, enter a prompt that asks Agent Builder to create your new agent. In the prompt, enter the agent’s name along with a brief description that explains what the agent is for, who its target audience is, and what you want it to do. Although you can choose a template at the bottom of the page to base your agent on, don't select a template for this exercise. The purpose of this exercise is to create a fully custom agent from scratch.
 
-1. After you enter a description and select the forward arrow, the **Agent Builder** form should appear for your new agent. At the top of the form is a **Describe** tab and a **Configure** tab.
+1. After you enter a description and select the **Send** button, the **Agent Builder** form should appear for your new agent. The Agent Builder chat pane appears on the left, and the agent details appear on the right. At the top of the form are a **Configure** tab and a **Try It** tab.
 
-    - The **Describe** tab enables you to carry on a conversation with Agent Builder. This tab is displayed by default.
+    - The Agent Builder chat pane on the left enables you to carry on a conversation with Agent Builder to refine your agent.
+
+    - The **Try It** tab enables you to test the agent by entering starter prompts or custom messages. This tab is displayed by default.
 
     - The **Configure** tab enables you to define the detailed settings that drive the agent.
 
@@ -25,21 +27,20 @@ In this exercise, you're encouraged to be creative and design an agent that's of
 
 1. If you didn't provide a name for your agent in the description that you just entered, then Agent Builder typically provides a suggested name and asks you to either confirm the name or provide a new one. You should reply accordingly.
 
-1. At this point, Agent Builder typically prompts you to refine the description for your agent. It does so through a series of questions or suggested prompts. You can optionally respond to each question or select certain prompts until the agent's description is to your liking. 
+1. At this point, Agent Builder typically prompts you to refine the description for your agent. It does so through a series of questions or suggested prompts. You can optionally respond to each question or select certain prompts until the agent's description is to your liking.
 
    > [!IMPORTANT]
    > The beauty of the Agent Builder process is that it automatically translates your basic, natural language description into a complex set of instructions. This process saves you from creating this detailed instruction set on your own.
 
 1. Once you're satisfied with the agent's description, select the **Configure** tab at the top of the form. Let’s see what Agent Builder did based on your finalized description.
 
-1. On the **Configure** tab, ignore the **Template** and **Agent icon** options for now. In a real-world scenario, you can optionally select a template that you want to base your agent upon, and you can assign your agent a custom icon. Notice how the **Name** and **Description** fields are filled in based on your finalized description. 
+1. On the **Configure** tab, ignore the **Template** and **Agent icon** options for now. In a real-world scenario, you can optionally select a template that you want to base your agent upon, and you can assign your agent a custom icon. Notice how the **Name** and **Description** fields are filled in based on your finalized description.
 
-1. Scroll down to the **Instructions** field. Agent Builder generated these instructions based on your initial description and the updates that you made to it on the **Describe** tab. Review the detailed level of instructions that Agent Builder generated.
+1. Scroll down to the **Instructions** section. Agent Builder generated these instructions based on your initial description and the updates that you made to it. Review the detailed level of instructions that Agent Builder generated.
 
-1. If you wish to change the instructions, you can either manually edit them directly in the **Instructions** field, or you can ask Agent Builder to update the instructions for you.  
+1. If you wish to change the instructions, you can either manually edit them directly in the **Instructions** field, or you can ask Agent Builder to update the instructions for you.
 
-1. While the current instructions look good, you wonder if they could be improved upon. You aren't sure how to improve them, so you decide to ask Agent Builder what it thinks.  
-    <br/>To do so, select the **Describe** tab. In the **Describe** tab, enter a prompt that asks Agent Builder what other instructions it would recommend that could improve this agent.
+1. While the current instructions look good, you wonder if they could be improved upon. You aren't sure how to improve them, so you decide to ask Agent Builder what it thinks. In the Agent Builder chat pane on the left, enter a prompt that asks Agent Builder what other instructions it would recommend that could improve this agent.
 
 1. Review Agent Builder’s recommendations. If you’re pleased with its suggestions, ask Agent Builder to add them to the agent’s instructions.
 
@@ -50,21 +51,21 @@ In this exercise, you're encouraged to be creative and design an agent that's of
    > [!WARNING]
    > If you don't add any public websites or work data to your agent, it might still be able to respond to your requests, but only using general capabilities of the underlying large language model (LLM), such as answering common knowledge questions, basic reasoning, or generating generalized text. As such, it's recommended that you ground your agents in specific work data or public websites; otherwise, the agent's responses might lack the context or relevance needed for business-specific tasks.
 
-1. In the **Capabilities** section, you can optionally enable the **Code interpreter** and **Image generator** tools by selecting their toggle switches. Both tools are turned Off by default.
+1. In the **Capabilities** section, you can optionally enable or disable the **Create documents, charts, and code** and **Create images** tools by selecting their toggle switches. Both tools are turned on by default.
 
-1. In the **Suggested prompts** section, Agent Builder Studio displays the suggested prompts that it automatically created when you entered the agent's description back on the **Describe** tab. You can edit or delete any of the existing prompts or add new ones.
+1. In the **Suggested prompts** section, Agent Builder displays the suggested prompts that it automatically created when you entered the agent's description. You can edit or delete any of the existing prompts or add new ones.
 
-1. In the **Agent preview** pane on the right side of the page, you can optionally test the agent by selecting several of the suggested prompts or submitting custom prompts. Verify the agent is correctly pulling in data from the knowledge source documents. 
+1. In the **Try It** tab on the top of the form, you can optionally test the agent by selecting several of the suggested prompts or submitting custom prompts. Verify the agent is correctly pulling in data from the knowledge source documents.
 
 1. You can test your agent as long as you want and refine your configuration if it isn't working or responding as you intended. You can do so by either manually updating the **Instructions**, or by updating the **Description**, in which case Agent Builder automatically updates the **Instructions** based on the changes you made to the **Description**.
 
-1. Once you feel the agent is configured properly and you're satisfied with the results of the suggested prompts, select the **Create** button at the top of the page.  
+1. Once you feel the agent is configured properly and you're satisfied with the results of the suggested prompts, select the **Create** button at the top of the page.
 
 1. Once the agent is created, a dialog box appears that indicates the agent was successfully created. In this dialog box, you can either go to the agent or share it. Select the **Go to agent** option.
 
    > [!NOTE]
    > At this stage, the agent is private and accessible only to you. In a real-world scenario where the agent needs to be used by multiple team members, you would share it with those individuals. For this training exercise, sharing isn’t required since you’re working within your own tenant.
 
-1. On your agent's window, note how the agent appears in the navigation pane. Feel free to enter any of the starter prompts or enter any other custom prompts to run the agent. 
+1. On your agent's window, note how the agent appears in the navigation pane. Enter any of the starter prompts or any other custom prompts to test the agent.
 
-1. When you're done using the agent, select **All agents** in the navigation pane. In your **Agent Store** window that appears, note how your agent is displayed in the **Your agents** section. You can access this agent from the Agent Store, or you can select the pin icon that appears next to the agent in the navigation pane if you want the agent to always display under the list of agents in the pane. 
+1. When you're done using the agent, select **All agents** in the navigation pane. The **Agent Store** window appears and displays your agent in the **Your agents** section. You can access the agent from the Agent Store at any time, or you can select the pin icon next to the agent in the navigation pane to keep it visible under the list of agents.

--- a/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/6-exercise-create-copilot-chat-agent.md
+++ b/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/6-exercise-create-copilot-chat-agent.md
@@ -1,6 +1,6 @@
 ---
 lab:
-  title: Exercise - Create a Copilot chat agent
+  title: Untitled exercise
   description: In this exercise, you're encouraged to be creative and design an agent that's of significant interest to you. For example, you might want to solve a real-world business problem, improve productivity in a specific area at your company, or address a personal topic that interests you. Because each student creates their own personal agent, the instructions in this exercise focus on the structure and order of how to configure an agent rather than specifying actual values to enter in each field. It's up to you to decide what you want to enter in each field as you create your agent.
   duration: 54 minutes
   level: 100


### PR DESCRIPTION
## Summary

This PR updates the Module 03 Exercise 06 (Create a Copilot chat agent) lab instructions to match the current Agent Builder UI in Microsoft 365 Copilot. The exercise had multiple references to outdated UI elements, renamed features, and an incorrect portal URL.

## Changes

- Updated the Microsoft 365 portal URL from `https://www.microsoft365.com` to `https://m365.cloud.microsoft.com` and renamed it to **Microsoft 365 Copilot**
- Added a proper lab title (`Exercise - Create a Copilot chat agent`) replacing the placeholder `Untitled exercise`
- Replaced references to the removed **Describe** tab with the **Agent Builder chat pane** (now on the left side of the form)
- Updated the tab layout description: **Describe** + **Configure** tabs are now **Configure** + **Try It** tabs
- Renamed the submit button from **forward arrow** to **Send** button
- Renamed **Agent Builder Studio** to **Agent Builder**
- Updated **Instructions** from a single field reference to a section reference
- Renamed capabilities: **Code interpreter** and **Image generator** are now **Create documents, charts, and code** and **Create images**, and both default to on instead of off
- Replaced **Agent preview** pane reference with the **Try It** tab
- Removed trailing whitespace from multiple lines

## Files changed

- `Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/6-exercise-create-copilot-chat-agent.md` — Updated lab title, portal URL, and all UI references to match current Agent Builder interface


Fixes #6 

## Markdown test
<img width="1221" height="1118" alt="image" src="https://github.com/user-attachments/assets/64f49e5d-54d6-442d-ad43-14c463b2244c" />
