### PR TITLE
fix(m02/ex05): update Researcher agent lab tenant note and navigation step

### DIFF
--- a/Instructions/Labs/M02-explore-prebuilt-microsoft-365-copilot-agents/05-exercise-researcher-agent.md
+++ b/Instructions/Labs/M02-explore-prebuilt-microsoft-365-copilot-agents/05-exercise-researcher-agent.md
@@ -16,7 +16,7 @@ In today's fast-paced workplace, the ability to quickly synthesize large volumes
 This lab offers a hands-on opportunity to explore how the Researcher agent can help you uncover insights, organize information, and generate polished outputs from your own data, all within the familiar Microsoft 365 environment. Whether you're consolidating project updates, gathering stakeholder input, or preparing for executive discussions, this lab demonstrates how Copilot can enhance your productivity and ensure you're always ready with the right information at the right time.
 
 > [!NOTE]
-> This course doesn't include a Microsoft 365 lab tenant with fictitious Outlook and Teams data. Instead, you must complete this training exercise using your own personal data.
+> If you're using a Microsoft 365 lab tenant, review the available content in **Outlook**, **Microsoft Teams**, and **OneDrive** before starting this exercise. Researcher can use emails, conversations, meetings, and files from these applications as sources for analysis. If you're using your own Microsoft 365 environment, Researcher will use the content available to you.
 
 In this training exercise, you plan to use the Researcher agent to synthesize information across Outlook, OneDrive, and Teams to prepare insights on a topic from your own data.
 

--- a/Instructions/Labs/M02-explore-prebuilt-microsoft-365-copilot-agents/05-exercise-researcher-agent.md
+++ b/Instructions/Labs/M02-explore-prebuilt-microsoft-365-copilot-agents/05-exercise-researcher-agent.md
@@ -26,7 +26,7 @@ Think of an actual project that you participated in over the past 90 days. Amids
 
 With a simple command, you can instruct the platform to collate and distill the essence of your emails and chats pertaining to the project over the past month. In doing so, note how the agent effortlessly sifts through the information clutter. It then presents you with a concise summary that not only captures the progress made but also highlights any key decisions, challenges, and emerging trends. This exercise exemplifies how using the Researcher agent can save you valuable time while ensuring you stay well-informed and in control of the crucial aspects of your business endeavors.
 
-1. In **Microsoft 365 Copilot**, in the navigation pane, select the **Researcher** agent under the **Agents** section. If the **Researcher** agent doesn't appear, select **All agents** in the navigation pane, and then in the **Agent Store** window, select **Researcher** under the **Built by Microsoft** section.
+1. In **Microsoft 365 Copilot**, in the navigation pane, select the **Researcher** agent under the **Agents** section. If the **Researcher** agent doesn't appear, select **More agents** in the navigation pane, and then in the **Agent Store** window, select **Researcher** under the **Built by Microsoft** section.
 
 1. The **Researcher** agent window appears. In the prompt field, enter the following prompt, replacing `<Topic X>` with an actual project name or topic that you participated in at your organization: `Help me gather and summarize all recent discussions, documents, and emails related to <Topic X> from the past 90 days`.
 


### PR DESCRIPTION
## Summary

Updates the Researcher agent exercise in Module 02 to reflect the current Microsoft 365 Copilot UI and to correctly describe lab tenant data availability. Both changes keep the lab accurate for learners using either a Microsoft 365 lab tenant or their own environment.

## Changes

- Rewrote the opening note so learners using a Microsoft 365 lab tenant know to review available **Outlook**, **Microsoft Teams**, and **OneDrive** content before starting, and clarified that Researcher uses whatever content is available in their own environment (replaces the previous note stating no lab tenant data is provided).
- Updated the navigation step to select **More agents** instead of the outdated **All agents** option when the Researcher agent isn't visible in the navigation pane.

## Files changed

- `Instructions/Labs/M02-explore-prebuilt-microsoft-365-copilot-agents/05-exercise-researcher-agent.md` — revised the lab tenant note and corrected the agent navigation label to match the current UI.