### PR TITLE
fix(M03-ex06): repair broken simulated SharePoint agent lab link

### DIFF
--- a/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/8-exercise-create-sharepoint-agent.md
+++ b/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/8-exercise-create-sharepoint-agent.md
@@ -27,7 +27,7 @@ In this exercise, you want to create a SharePoint agent to help you get quick an
 
    Select the SharePoint site that you want to use.
 
-1. If you don’t have a SharePoint site to use for this exercise, then select the following link to open the simulated lab environment in your browser: [Start the simulated SharePoint agent lab](https://app.highlights.guide/start/75485962-4a29-41d8-a8b6-151fca8591c1?token=ac1f6c5a-9d10-4ed5-bd04-d7db595c1d02).
+1. If you don’t have a SharePoint site to use for this exercise, then select the following link to open the simulated lab environment in your browser: [Start the simulated SharePoint agent lab](https://cvsr8rrncj-g7aswbmvdv.app.highlights.guide/sites/Mark8ProjectTeam).
 
     This simulation opens the Mark 8 Team Site for Fabrikam.
 


### PR DESCRIPTION
## Summary

Fixes the broken simulated lab hyperlink in Module 3, Exercise 6 (Create a SharePoint agent). The previous `app.highlights.guide/start/...?token=...` URL returned an HTTP 401 error because the security token was invalid/expired. It now points to the working simulation URL. Resolves #21.

## Changes

- **M03 – Exercise 6, Step 2:** Replaced the broken tokenized simulation link (`https://app.highlights.guide/start/75485962-4a29-41d8-a8b6-151fca8591c1?token=...`), which returned HTTP 401, with the working environment URL (`https://cvsr8rrncj-g7aswbmvdv.app.highlights.guide/sites/Mark8ProjectTeam`).

## Files changed

- `Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/8-exercise-create-sharepoint-agent.md` — updated the "Start the simulated SharePoint agent lab" hyperlink to the working simulation URL.

## Reply to issue #21

Thanks for reporting this. You're right — the hyperlink in EX6, Step 2 was returning an HTTP 401 because the security token in the URL was no longer valid. This PR replaces the broken tokenized link with the working simulation URL (`https://cvsr8rrncj-g7aswbmvdv.app.highlights.guide/sites/Mark8ProjectTeam`), so the "Start the simulated SharePoint agent lab" link now opens the Mark 8 Team Site correctly.

Fix #21 
