### PR TITLE
fix(m03/ SharePoint exercise): update SharePoint agent lab steps

### DIFF
--- a/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/8-exercise-create-sharepoint-agent.md
+++ b/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/8-exercise-create-sharepoint-agent.md
@@ -92,4 +92,4 @@ Use a SharePoint site that contains content such as documents, pages, or lists. 
 
 1. Take some time to test the agent. You can use any of the starter prompts or enter custom prompts.
 
-1. If you want to make any changes to the agent, select the **ellipsis (...)** icon in the upper corner of the agent pane. In the drop-down menu that appears, select **Edit agent**. The **Edit agent** window opens, which is a replica of the **Create your new agent** window. Navigate through the tabs to update the properties you want to change and then save your changes.
+1. If you want to make any changes to the agent, select the **ellipsis (...)** icon in the upper-right corner of the agent pane. In the drop-down menu that appears, select **Edit agent**. The **Edit agent** window opens, which is a replica of the **Create your new agent** window. Navigate through the tabs to update the properties you want to change and then save your changes.

--- a/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/8-exercise-create-sharepoint-agent.md
+++ b/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/8-exercise-create-sharepoint-agent.md
@@ -68,7 +68,7 @@ Use a SharePoint site that contains content such as documents, pages, or lists. 
 
    1. The **Pick items** window opens. Browse the available libraries and lists for the site. Select the document library, folder, file, page, or list that you want to add as a knowledge source for the agent.
 
-      - **Select all the files and folders in the Documents library**. Open the **Documents** library, toggle selection for all items, and then select **Select**. You return to the **Sources** tab, where the selected files and folders appear below the SharePoint site source.
+      - **Select all the files and folders in the Documents library**. Open the **Documents** library, select the checkbox to toggle selection for all items, and then select **Select**. You return to the **Sources** tab, where the selected files and folders appear below the SharePoint site source.
 
       - **Select specific files and folders within the Documents library**. Select one or more files or folders. A check mark appears next to each selected item. Select **Select** to return to the **Sources** tab, where the selected files and folders appear below the SharePoint site source.
 

--- a/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/8-exercise-create-sharepoint-agent.md
+++ b/Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/8-exercise-create-sharepoint-agent.md
@@ -1,7 +1,7 @@
 ---
 lab:
   title: Create a SharePoint agent
-  description: 'In this exercise, you want to create a SharePoint agent to help you get quick answers or perform useful actions that are related to a specific SharePoint site you already use. You can perform this exercise using one of the following options:'
+  description: 'In this exercise, you want to create a SharePoint agent to help you get quick answers or perform useful actions that are related to a specific SharePoint site you already use.'
   duration: 20 minutes
   level: 100
   islab: true
@@ -11,75 +11,85 @@ lab:
 
 As organizations rely more heavily on SharePoint to manage knowledge, projects, and team resources, the ability to create intelligent agents that interact with this content becomes a powerful productivity booster. Microsoft 365 Copilot makes it possible to build a SharePoint-based Copilot agent that can quickly surface information, answer questions, and assist users in navigating complex site content. This lab guides you through the process of creating your own SharePoint-connected Copilot agent, one that understands the structure and data of a real site you use every day.
 
-Through this hands-on exercise, you learn how to create a SharePoint site, configure it as a data source, and customize your agent's behavior and responses. From onboarding support to project tracking or team resource assistance, you design and test an agent tailored to your needs. After you complete this lab, you should have a functioning SharePoint agent and a deeper understanding of how AI can make site content more accessible and actionable for users across your team or organization.
+Through this hands-on exercise, you learn how to create a SharePoint agent from an existing SharePoint site, configure its sources, and customize the agent's behavior and responses. From onboarding support to project tracking or team resource assistance, you design and test an agent tailored to your needs. After you complete this lab, you should have a functioning SharePoint agent and a deeper understanding of how AI can make site content more accessible and actionable for users across your team or organization.
 
 ### Exercise - Create a SharePoint agent
 
-In this exercise, you want to create a SharePoint agent to help you get quick answers or perform useful actions that are related to a specific SharePoint site you already use. You can perform this exercise using one of the following options:
+In this exercise, you want to create a SharePoint agent to help you get quick answers or perform useful actions that are related to a specific SharePoint site you already use.
 
-- If you have access to a SharePoint site, such as a team site, project site, or resource hub, then you can use that site.
-- If you don't have access to a SharePoint site, then you can still perform the steps in this exercise using a simulated lab environment. The simulation uses a fictitious SharePoint site for Fabrikam.
+To complete this exercise, you must have access to a SharePoint site that contains pages, documents, or other content that can be used as agent knowledge sources.
 
-1. If you have a site that you plan to use for this exercise, then navigate to the **Microsoft 365 Copilot** home page, select the **App Launcher** icon (grid icon) on the top left, and then select **SharePoint**. Review the sites that appear in the navigation pane. The site that you select should ideally be one that contains documents, lists, or pages with project information, team resources, or other knowledge sources. For example:
+Use a SharePoint site that contains content such as documents, pages, or lists. Examples include:
+- A team site
+- A project site
+- A resource hub site
+- A Teams-connected SharePoint site
+
+1. Navigate to the **Microsoft 365 Copilot** home page at `https://m365.cloud.microsoft.com`, select the **App Launcher** icon (grid icon) on the top left, and then select **SharePoint**. 
+
+   Review the sites that appear in the navigation pane. The site that you select should ideally be one that contains documents, lists, or pages with project information, team resources, or other knowledge sources. For example:
    - A personal OneDrive site with shared documents
    - A Teams-connected SharePoint site
    - A shared project or department site
 
    Select the SharePoint site that you want to use.
 
-1. If you don’t have a SharePoint site to use for this exercise, then select the following link to open the simulated lab environment in your browser: [Start the simulated SharePoint agent lab](https://cvsr8rrncj-g7aswbmvdv.app.highlights.guide/sites/Mark8ProjectTeam).
-
-   This simulation opens the Mark 8 Team Site for Fabrikam.
+1. If you don't have a SharePoint site available, ask your trainer or lab administrator whether a sample site has been provisioned for this course. Otherwise, you can create a new SharePoint site (or use a personal OneDrive site) with a few sample documents so that you have content to work with for the rest of this exercise.
 
 1. There are four places from which you can initiate the process to create a new agent for a site:
    - The SharePoint site's home page
-   - The command bar of a document library
+   - The command bar of a document library or list
    - The context menu of the selected files in a document library
    - The agent chat pane
 
-    Whether you're using your own SharePoint site or the simulated site, use the site's home page. On the site home page, select **+ New**, and then in the drop-down menu that appears, select **Agent**.
+   For this exercise, use the site's home page. On the site home page, select **+ New**, and then in the drop-down menu that appears, select **Agent**.
 
-1. On the **Create your new agent** window, the Copilot agent tool in SharePoint creates a draft version of your agent for the selected site. Notice that in the middle of the window, it indicates the source for this agent (which is your selected site). If an **Edit** option is available, select it to view and modify the agent configuration. The **Create your new agent** window then displays the editable form.
+1. On the **Create your new agent** window, SharePoint creates a draft version of the agent for the selected site. You can review and modify the agent's configuration before creating it.
 
-1. The **Create your new agent** form has three tabs - **Overview**, **Sources**, and **Behavior**. The **Overview** tab is displayed first by default. From this tab, you must enter the agent's name and purpose. Default values are provided for each field, but you can change them now if you want.
+1. The **Create your new agent** window includes three tabs: **Overview**, **Sources**, and **Behavior**. The **Overview** tab is displayed by default. From this tab, you can review or update the agent's name, icon, and purpose. Select the **Sources** tab to review and modify the content sources included in the agent, and select the **Behavior** tab to customize the agent's behavior.
 
-1. The **Overview** tab also displays the default icon associated with the agent. If you're using the simulated lab, you can't change the agent's icon. However, if you're using your own personal site, you can select the **Change** option that appears below the icon if you want to customize it. An agent icon must be a `.png` file that doesn't exceed 1 MB in size. If you don't have an icon to use, proceed to the next step.
+1. The **Overview** tab also displays the default icon associated with the agent. If you want to customize it, select the **Change** option that appears below the icon. An agent icon must be a `.png` file that doesn't exceed 1 MB in size. If you don't have an icon to use, proceed to the next step.
 
-1. At this stage, notice that the **Save and close** button is enabled. You could select it at this point, but don't do that yet. If you did, the tool would accept the default knowledge sources and behavioral attributes for your agent. It would also make the agent live instead of keeping it in draft mode. While you could still make changes later, for the purposes of this lab, continue working in draft mode to configure the remaining agent attributes. Select the **Sources** tab.
+1. The **Create agent** button is already available. While you could create the agent now using the default settings, continue configuring the agent in the remaining steps so that you can review and customize its sources and behavior before creating it. Select the **Sources** tab.
+
+1. The **Sources** tab lets you review and manage the knowledge sources used by the agent. By default, the SharePoint site from which you created the agent is included as a source.
+
+   To add more sources, you can use one of the following options:
+
+   - Enter a site name or URL in the **Search by site title or enter a URL** field.
+
+   - Select **From OneDrive** to add content from OneDrive.
+
+   - Select the **ellipsis (...)** menu next to the SharePoint site and then select **Add contents from this site** to add document libraries, folders, files, pages, or lists from the current site.
+
+   You can add up to 20 sources. Review the configured sources and add any additional sources that you want the agent to use.
+
+   1. On the **Sources** tab, select the **ellipsis (...)** menu next to the SharePoint site, and then select **Add contents from this site**.
+
+   1. The **Pick items** window opens. Browse the available libraries and lists for the site. Select the document library, folder, file, page, or list that you want to add as a knowledge source for the agent.
+
+      - **Select all the files and folders in the Documents library**. Open the **Documents** library, toggle selection for all items, and then select **Select**. You return to the **Sources** tab, where the selected files and folders appear below the SharePoint site source.
+
+      - **Select specific files and folders within the Documents library**. Select one or more files or folders. A check mark appears next to each selected item. Select **Select** to return to the **Sources** tab, where the selected files and folders appear below the SharePoint site source.
+
+1. Once you're back on the **Sources** tab, you can select the **+ Add contents from this site** option if you want to add more libraries, files, or folders.
 
    > [!NOTE]
-   > Depending on the SharePoint environment, the button label differs. In the updated SharePoint agent experience, this button appears as **Create agent** instead of **Save and close**.
+   > You can add content from other SharePoint sites or from OneDrive by using the options available on the **Sources** tab.
 
-1. The **Sources** tab enables you to define more sources to the draft version of your agent. The default source for a SharePoint agent is the entire SharePoint site. You can see this option in the source field, where the default value is **Sourced from entire site**. This option uses all the data sources in this site. However, if you want to select more granular sources, then select this field, and in the drop-down menu that appears, select **Sourced from document libraries, folders, or files**. You can decide which source option you prefer. If you select the **Sourced from document libraries, folders, or files** option, then complete the following steps:
-
-   1. When you select the **Sourced from document libraries, folders, or files** option, the following option appears below it: **+ Add document libraries, folders, or files**. Select this menu option, which displays the **Pick items** window.
-
-   1. The **Pick items** window displays the **Documents** folder for the SharePoint site associated with the agent. You have two options for selecting files and folders:
-
-      - **Select all the files and folders in the Documents library**. Choose the **Select** button to select the entire Documents library. Doing so returns you to the **Sources** tab, which displays **Documents** below the **Sourced from document libraries, folders, or files** field.
-
-      - **Select specific files and folders within the Documents library**. When you select one or more files or folders, a check mark appears next to the selected files and folders. Doing so returns you to the **Sources** tab and displays the selected files and folders below the **Sourced from document libraries, folders, or files** field.
-
-   > [!NOTE]
-   > The SharePoint agent creation experience can vary depending on your SharePoint environment. Some controls and option names might differ from those shown in this exercise. If you don't see **Sourced from entire site** or **Sourced from document libraries, folders, or files**, use the available option to add or manage document libraries, folders, or files as agent knowledge sources.
-
-1. Once you're back on the **Sources** tab, you can select the **+ Add document libraries, folders, or files** option if you want to add more libraries, files, or folders.
-
-1. After you finish defining your sources, select the **Behavior** tab. The **Behavior** tab allows you to define a **Welcome** message, which is displayed when a user selects this agent in SharePoint. This message field is available in SharePoint agents, but not in Copilot Chat agents.
+1. After you finish defining your sources, select the **Behavior** tab. The **Behavior** tab allows you to define a Welcome message, which is displayed when a user selects this agent in SharePoint. This message field is available in SharePoint agents, but not in Copilot Chat agents.
 
 1. From here, you can configure up to three starter prompts.
 
 1. Finally, you can define the instructions for the agent using natural language text, just like you do when creating an agent in Copilot Chat.
 
-1. After you finish making your changes to the SharePoint agent, depending on your SharePoint environment, select **Save and close** or **Create agent** to save your changes. Since you are still in draft mode, saving the draft version of the agent converts it to a live SharePoint agent.
+1. After you finish making your changes to the SharePoint agent, select **Create agent** to save your changes. The draft configuration is saved and the agent is created.
 
    > [!NOTE]
    > If you experience any issues when creating the agent, select the **Documents** library in the navigation pane, select the folders or files that you want to use as the agent source, and then select **Copilot** &gt; **Create an agent**. This action opens the **Create your new agent** window, where you can continue to configure the agent.
 
-1. Select the **X** in the upper corner of the **Create your new agent** window to close it. Doing so returns you to the SharePoint site's home page, and the agent appears on the right side of the window.
-
-  
+1. Review the **Your agent is ready to use** confirmation message. Select **Chat with agent** to open the newly created agent. The SharePoint site's home page reappears, and the agent chat pane opens on the right side of the page.
 
 1. Take some time to test the agent. You can use any of the starter prompts or enter custom prompts.
 
-1. If you're using the simulation, then you're now finished with this exercise. The simulation isn't programmed to edit the agent. However, if you're using your own personal SharePoint site, then you can perform this final step if you want to make any changes to the agent. Select the ellipsis icon in the upper corner of the agent pane. In the drop-down menu that appears, select **Edit agent**. The **Edit agent** window opens, which is a replica of the **Create your new agent** window. Navigate through the tabs to update the properties you want to change and then save your changes.
+1. If you want to make any changes to the agent, select the **ellipsis (...)** icon in the upper corner of the agent pane. In the drop-down menu that appears, select **Edit agent**. The **Edit agent** window opens, which is a replica of the **Create your new agent** window. Navigate through the tabs to update the properties you want to change and then save your changes.


### PR DESCRIPTION
## Summary

Refreshes the Module 03 SharePoint agent exercise for the current SharePoint agent creation experience. The instructions now use an existing SharePoint site and provide clearer guidance for configuring sources and accessing the completed agent.

## Changes

### M03 – Create a SharePoint agent

- Removed the simulated lab environment path and clarified the requirement to use a SharePoint site with suitable content.
- Updated navigation and agent creation steps to reflect the current SharePoint UI.
- Reworked the **Sources** tab instructions to cover adding content from the current site, other SharePoint sites, and OneDrive.
- Added instructions for selecting all items in a document library by using the selection checkbox.
- Updated agent configuration and completion terminology, including **Create agent**, **Chat with agent**, and the upper-right **Edit agent** menu.

## Files changed

- `Instructions/Labs/M03-build-manage-no-code-agent-sharepoint/8-exercise-create-sharepoint-agent.md` — Updated the SharePoint agent creation exercise for current UI behavior and source-management options.